### PR TITLE
arc-waker: Waker types must be Send + Sync.

### DIFF
--- a/arc-waker/src/lib.rs
+++ b/arc-waker/src/lib.rs
@@ -6,7 +6,7 @@ use std::mem;
 use std::task::{RawWaker, RawWakerVTable, Waker};
 
 /// Wake a pending task
-pub trait Wake: Sized {
+pub trait Wake: Send + Sync + Sized {
     /// Wake up the task associated with this `Wake` value.
     fn wake(self: Arc<Self>) {
         self.wake_by_ref();


### PR DESCRIPTION
`Waker` types must be `Send + Sync`. For this to hold, types contained
by `Arc` must also be `Send + Sync`. However, `Arc::new` does not
contain this bound.

To make the arc waker abstraction safe, the `Wake` trait itself is bound
by `Send + Sync`.